### PR TITLE
Handle too short values

### DIFF
--- a/lib/exemvi/qr/mp/object.ex
+++ b/lib/exemvi/qr/mp/object.ex
@@ -717,7 +717,10 @@ defmodule Exemvi.QR.MP.Object do
   end
 
   @doc false
-  @deprecated "Not used outside unit tests"
+  if Mix.env() != :test do
+    @deprecated "Not used outside unit tests"
+  end
+
   def id_raw(template, id_atom) do
     id_atoms(template)
     |> Enum.find(fn {_, v} -> v == id_atom end)

--- a/test/mpm_test.exs
+++ b/test/mpm_test.exs
@@ -87,6 +87,18 @@ defmodule MPMTest do
     assert Enum.member?(reasons, Exemvi.Error.invalid_value_length)
   end
 
+  test "qr is too short" do
+    for qr <- ["", "123"] do
+      {:error, reasons} = MP.validate_qr(qr)
+      assert Enum.member?(reasons, Exemvi.Error.invalid_qr())
+    end
+  end
+
+  test "qr is blank" do
+    {:error, reasons} = MP.validate_qr("          ")
+    assert Enum.member?(reasons, Exemvi.Error.invalid_qr())
+  end
+
   test "qr does not start with payload format indicator" do
     wrong_payload = "01" <> @official_sample
     {:error, reasons} = MP.validate_qr(wrong_payload)


### PR DESCRIPTION
Previously, if a user attempted to validate a string value shorter than 4 characters, the code would crash.

The first commit contains the fix along with regression tests, while the 2 subsequent commits refactor the tests (i.e. if only the first commit is merged, the problem will still be fixed).

Note that the test refactoring commit contains only pure refactoring: both the count and logic of the previous tests has been preserved.