### PR TITLE
Fix for unexpected negative value length

### DIFF
--- a/lib/exemvi/qr/mp/mp.ex
+++ b/lib/exemvi/qr/mp/mp.ex
@@ -98,7 +98,7 @@ defmodule Exemvi.QR.MP do
 
     value_length =
       case Integer.parse(value_length_raw) do
-        {i, ""} -> i
+        {i, ""} when i > 0 -> i
         _ -> 0
       end
 

--- a/test/mpm_test.exs
+++ b/test/mpm_test.exs
@@ -601,4 +601,9 @@ defmodule MPMTest do
       invalid_value: :globally_unique_identifier
     )
   end
+
+  test "does not crash on uuid" do
+    {:error, [:invalid_value_length]} =
+      MP.parse_to_objects("36126243-615d-4033-86b6-32d82bace560")
+  end
 end

--- a/test/mpm_test.exs
+++ b/test/mpm_test.exs
@@ -602,8 +602,8 @@ defmodule MPMTest do
     )
   end
 
-  test "does not crash on uuid" do
+  test "does not crash on negative length" do
     {:error, [:invalid_value_length]} =
-      MP.parse_to_objects("36126243-615d-4033-86b6-32d82bace560")
+      MP.parse_to_objects("33-86b6-32d82bace560")
   end
 end


### PR DESCRIPTION
Hey!

Thanks for creating this library. We are glad we can use it!

We are using the library for parsing QR codes with different formats, so we check if a QR is in EMV format and if not, we try other things. Today, we triggered a quite unlikely scenario, where passing a UUID thrown an exception instead of returning error.

```
iex(14)> Exemvi.QR.MP.parse_to_objects "36126243-615d-4033-86b6-32d82bace560"
** (FunctionClauseError) no function clause matching in String.slice/3

    The following arguments were given to String.slice/3:

        # 1
        "33-86b6-32d82bace560"

        # 2
        4

        # 3
        -8

    Attempted function clauses (showing 3 out of 3):

        def slice(_, _, 0)
        def slice(string, start, length) when is_binary(string) and is_integer(start) and is_integer(length) and start >= 0 and length >= 0
        def slice(string, start, length) when is_binary(string) and is_integer(start) and is_integer(length) and start < 0 and length >= 0

    (elixir 1.16.3) lib/string.ex:2277: String.slice/3
    (exemvi 0.2.2) lib/exemvi/qr/mp/mp.ex:113: Exemvi.QR.MP.parse_to_objects_rest/3
    iex:11: (file)
```

This is because by sheer accident, the beginning of the UUID can be a beginning of an EMV code, but during parsing, the two characters for length include dash "-8". This gets parsed to integer `-8` that later breaks the `String.slice`.

The fix adds an expectation that parsed length is positive.

Let me know if I should change anything in the PR and thanks again for your amazing library ❤️ 